### PR TITLE
マイク認識最低時間を実装

### DIFF
--- a/src/py-recognition/src/__main__.py
+++ b/src/py-recognition/src/__main__.py
@@ -82,9 +82,6 @@ def __whiper_help(s:str) -> str:
 @click.option("--google_duplex_parallel_max", default=None, help="(google_duplexのみ)複数並列リクエスト数増減時の最大並列数", type=int)
 @click.option("--google_duplex_parallel_reduce_count", default=None, help="(google_duplexのみ)増加した並列数を減少するために必要な成功数", type=int)
 @click.option("--google_tcp", default=None, help="-", type=click.Choice(["urllib", "requests"]), callback=select_google_tcp, expose_value=False, is_eager=True)
-@click.option("--mic", default=None, help="使用するマイクのindex", type=int)
-@click.option("--mic_name", default=None, help="マイクの名前を部分一致で検索します。--micが指定されている場合この指定は無視されます", type=str)
-#@click.option("--mic_api", default=val.MIC_API_VALUE_MME, help="--mic_nameで検索するマイクのAPIを指定します", type=click.Choice(val.ARG_CHOICE_MIC_API))
 
 @click.option("--transcribe_filter", default=None, help="変換フィルタルールファイル", type=str)
 
@@ -101,9 +98,13 @@ def __whiper_help(s:str) -> str:
 @click.option("--subtitle_obs_text_ja", default=None, help="字幕(ja_JP)テキストオブジェクトの名前", type=str)
 @click.option("--subtitle_obs_text_en", default=None, help="字幕(en_US)テキストオブジェクトの名前", type=str)
 
+@click.option("--mic", default=None, help="使用するマイクのindex", type=int)
+@click.option("--mic_name", default=None, help="マイクの名前を部分一致で検索します。--micが指定されている場合この指定は無視されます", type=str)
+#@click.option("--mic_api", default=val.MIC_API_VALUE_MME, help="--mic_nameで検索するマイクのAPIを指定します", type=click.Choice(val.ARG_CHOICE_MIC_API))
 @click.option("--mic_energy_threshold", default=None, help="互換性のため残されています", type=float)
 @click.option("--mic_db_threshold", default=0, help="設定した値より小さい音を無言として扱う閾値", type=float)
 @click.option("--mic_pause_duration", default=0.5, help="声認識後追加でVADにかけていいく塊の秒数", type=float)
+@click.option("--mic_record_min_duration", default=0.7, help="マイクの入力がこの値より短い場合無視する秒数", type=float)
 #@click.option("--mic_sampling_rate", default=16000, help="-", type=int)
 @click.option("--mic_head_insert_duration", default=None, help="-", type=float)
 @click.option("--mic_tail_insert_duration", default=None, help="-", type=float)
@@ -169,6 +170,7 @@ def main(
     mic_energy_threshold:Optional[float],
     mic_db_threshold:float,
     mic_pause_duration:float,
+    mic_record_min_duration:float,
     mic_head_insert_duration:Optional[float],
     mic_tail_insert_duration:Optional[float],
 
@@ -279,6 +281,7 @@ def main(
             filter_vad_inst,
             filter_highPass,
             mic_pause_duration,
+            mic_record_min_duration,
             mp_mic,
             ilm_logger)
         ilm_logger.print(f"マイクは{mc.device_name}を使用します")

--- a/src/py-recognition/src/__main__.py
+++ b/src/py-recognition/src/__main__.py
@@ -104,7 +104,7 @@ def __whiper_help(s:str) -> str:
 @click.option("--mic_energy_threshold", default=None, help="互換性のため残されています", type=float)
 @click.option("--mic_db_threshold", default=0, help="設定した値より小さい音を無言として扱う閾値", type=float)
 @click.option("--mic_pause_duration", default=0.5, help="声認識後追加でVADにかけていいく塊の秒数", type=float)
-@click.option("--mic_record_min_duration", default=0.7, help="マイクの入力がこの値より短い場合無視する秒数", type=float)
+@click.option("--mic_record_min_duration", default=0.0, help="マイクの入力がこの値より短い場合無視する秒数", type=float)
 #@click.option("--mic_sampling_rate", default=16000, help="-", type=int)
 @click.option("--mic_head_insert_duration", default=None, help="-", type=float)
 @click.option("--mic_tail_insert_duration", default=None, help="-", type=float)

--- a/src/py-recognition/src/main_run.py
+++ b/src/py-recognition/src/main_run.py
@@ -92,6 +92,10 @@ def run(
         log_exception:Exception | None = None
         try:
             save_wav(record, index, data, mic.sample_rate, 2, logger)
+            # 長さチェック
+            if pcm_sec < mic.record_min_sec:
+                raise recognition.TranscribeException(f"録音データが短いためスキップ({round(pcm_sec, 2)}s)")
+
             # 認識用音声データ
             if recognition_model.required_sample_rate is None or mic.sample_rate == recognition_model.required_sample_rate:
                 d = data

--- a/src/py-recognition/src/main_run.py
+++ b/src/py-recognition/src/main_run.py
@@ -93,7 +93,7 @@ def run(
         try:
             save_wav(record, index, data, mic.sample_rate, 2, logger)
             # 長さチェック
-            if pcm_sec < mic.record_min_sec:
+            if (pcm_sec - (mic.start_insert_sec + mic.end_insert_sec)) < mic.record_min_sec:
                 raise recognition.TranscribeException(f"録音データが短いためスキップ({round(pcm_sec, 2)}s)")
 
             # 認識用音声データ

--- a/src/py-recognition/src/microphone.py
+++ b/src/py-recognition/src/microphone.py
@@ -78,6 +78,7 @@ class Microphone:
             filter_vad:filter.VoiceActivityDetectorFilter,
             filter_highPass:filter.HighPassFilter | None,
             phase2_sec:float,
+            record_min_sec:float,
             device:int|None,
             logger:Logger) -> None:
         self.__energy_threshold = energy_threshold
@@ -87,6 +88,7 @@ class Microphone:
         self.__device = device
         self.__vad_sec = 0.5
         self.__vad_phase2_sec = phase2_sec
+        self.__record_min_sec = record_min_sec
         self.__sample_rate = val.MIC_SAMPLE_RATE
         self.__sample_width = val.MIC_SAMPLE_WIDTH
         self.__chunk_size = 1024
@@ -113,6 +115,9 @@ class Microphone:
 
     @property
     def end_insert_sec(self) -> float: return self.__recog_conf.tail_insert_duration
+
+    @property
+    def record_min_sec(self) -> float: return self.__record_min_sec
 
     @property
     def sample_rate(self) -> int: return self.__sample_rate
@@ -165,6 +170,8 @@ class Microphone:
 
                 # chunk_sizeが小さい場合VADが認識しないのでvad_secバッファをためてVADにかける
                 #print("Phase.0")
+                temp = collections.deque()
+                ph2_frames = collections.deque()
                 for _ in range(vad_list_len):
                     self.__indicate(dB, _print)
 
@@ -177,6 +184,9 @@ class Microphone:
                     en = audioop.rms(buffer, val.MIC_SAMPLE_WIDTH)
                     dB = rms2db(en)
                     frames.append((buffer, en))
+                    ph2_frames.append(buffer)
+                    if vad_phase2_len < len(ph2_frames):
+                        ph2_frames.popleft()
 
                 # 開始音検索位置
                 #print("Phase.1")
@@ -200,28 +210,42 @@ class Microphone:
                     en = audioop.rms(buffer, val.MIC_SAMPLE_WIDTH)
                     dB = rms2db(en)
                     frames.append((buffer, en))
+                    ph2_frames.append(buffer)
+                    if vad_phase2_len < len(ph2_frames):
+                        ph2_frames.popleft()
 
                 # 声が含まれなくなるまでVADにかける
                 #print("Phase.2")
                 if is_overflowed:
                     continue
                 while True:
-                    temp = []
-                    for _ in range(vad_phase2_len):
-                        _buffer, overflowed = stream.read(self.__chunk_size)
-                        if(overflowed):
-                            self.__logger.error("overflowed")
-                            break
-                        buffer = self.filter(bytes(_buffer)) # type: ignore
-                        temp.append(buffer)
-                        db = rms2db(audioop.rms(buffer, val.MIC_SAMPLE_WIDTH))
-                        self.__indicate_pahse2(db, _print)
+                    #temp = []
+                    #for _ in range(vad_phase2_len):
+                    #    _buffer, overflowed = stream.read(self.__chunk_size)
+                    #    if(overflowed):
+                    #        self.__logger.error("overflowed")
+                    #        break
+                    #    buffer = self.filter(bytes(_buffer)) # type: ignore
+                    #    temp.append(buffer)
+                    #    db = rms2db(audioop.rms(buffer, val.MIC_SAMPLE_WIDTH))
+                    #    self.__indicate_pahse2(db, _print)
 
+                    _buffer, overflowed = stream.read(self.__chunk_size)
+                    if(overflowed):
+                        self.__logger.error("overflowed")
+                        break
+                    buffer = self.filter(bytes(_buffer)) # type: ignore
+                    db = rms2db(audioop.rms(buffer, val.MIC_SAMPLE_WIDTH))
+                    self.__indicate_pahse2(db, _print)
+                    ph2_frames.append(buffer)
+                    if len(ph2_frames) < vad_phase2_len:
+                        continue
+                    elif vad_phase2_len < len(ph2_frames):
+                        ph2_frames.popleft()
 
-                    buffer = b"".join(temp)
-                    frames.append((buffer, audioop.rms(buffer, val.MIC_SAMPLE_WIDTH)))
-                    b = b"".join(map(lambda x: x[0], frames))
-                    if not self.__filter_vad.check(b[-(vad_list_len * self.__chunk_size * 2):]):
+                    frames.append((_buffer, audioop.rms(buffer, val.MIC_SAMPLE_WIDTH)))
+                    b = b"".join(ph2_frames)
+                    if not self.__filter_vad.check(b):
                        break
                 if is_overflowed:
                     continue


### PR DESCRIPTION
VAD処理Phase.2を--mic_pause_duration(標準0.5s)ごとに処理ずるのではなく前フレームを残し逐次処理するように変更  
--mic_record_min_durationを用意  
短い認識時間を捨てられるように変更(ノイズ対策)  
  
--mic_record_min_durationの初期値は暫定です