### PR TITLE
illuminate連携時に字幕がボイロの発声に合わせて出るように修正

### DIFF
--- a/src/cs-illuminate/VoiceLink/Clients/VoiceVox.cs
+++ b/src/cs-illuminate/VoiceLink/Clients/VoiceVox.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using System.Web;
+using Newtonsoft.Json;
+
+namespace VoiceLink.Clients;
+public class VoiceVox : VoiceClient<NopVoiceObject, VoiceVoxSpeechClient, NopVoiceObject> {
+	private static HttpClient httpClient { get; } = new();
+
+	public override NopVoiceObject ClientParameter { get; } = new();
+
+	public override bool StartClient(bool isLaunch, NopVoiceObject extra) {
+		return true;
+	}
+
+	public override void EndClient() {}
+
+	public override void BeginSpeech(string text, VoiceVoxSpeechClient extra) {}
+	public override void Speech(string text, VoiceVoxSpeechClient extra) {
+
+		try {
+			var entry = $@"http://{extra.Host}:{extra.Port}";
+			AudioQuery? json;
+			{
+				using var request = new HttpRequestMessage(
+					HttpMethod.Post,
+					new Uri($"{entry}/audio_query?text={HttpUtility.UrlEncode(text)}&speaker={extra.Speaker}"));
+				using var response = httpClient.Send(request);
+				if (response.StatusCode != HttpStatusCode.OK) {
+					throw new VoiceLinkException("クエリの生成に失敗");
+				}
+
+				var @string = response.Content.ReadAsStringAsync();
+				@string.Wait();
+				json = JsonConvert.DeserializeObject<AudioQuery>(@string.Result);
+				if (json == null) {
+					throw new VoiceLinkException("食えりJSONのデシリアライズに失敗");
+				}
+			}
+
+			json.SpeedScale = extra.SpeedScale;
+			json.PitchScale = extra.PitchScale;
+			json.IntonationScale = extra.IntonationScale;
+			json.VolumeScale = extra.VolumeScale;
+			json.OutputSamplingRate = extra.OutputSamplingRate;
+			json.OutputStereo = extra.OutputStereo;
+
+			{
+				using var request = new HttpRequestMessage(
+					HttpMethod.Post,
+					new Uri($"{entry}/synthesis?speaker={extra.Speaker}&enable_interrogative_upspeak={true}")) {
+					Content = new StringContent(json.ToString(), Encoding.UTF8, @"application/json"),
+				};
+				using var response = httpClient.Send(request);
+				//using var response = httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+				if (response.StatusCode != HttpStatusCode.OK) {
+					throw new InvalidOperationException();
+				}
+				using var stream = response.Content.ReadAsStream();
+				{
+					var b = new byte[76800];
+					int ret;
+					while (0 < (ret = stream.Read(b, 0, b.Length))) {
+						extra.Writer.Write(b, 0, ret);
+					}
+				}
+			}
+		}
+		catch (AggregateException e) {
+			throw new VoiceLinkException("VOICEVOXと通信できません", e);
+		}
+		catch (Exception e) {
+			throw new VoiceLinkException("不明なエラー", e);
+		}
+	}
+
+	public override void EndSpeech(string text, VoiceVoxSpeechClient extra) {}
+}
+
+[JsonObject]
+file class JsonObject {
+	public override string ToString() => JsonConvert.SerializeObject(this);
+}
+
+[JsonObject]
+file class AudioQuery : JsonObject {
+	[JsonProperty("accent_phrases", Required = Required.Always)]
+	public AccentPhrases[] AccentPhrases { get; set; }
+
+	[JsonProperty("speedScale", Required = Required.Always)]
+	public double SpeedScale { get; set; }
+
+	[JsonProperty("pitchScale", Required = Required.Always)]
+	public double PitchScale { get; set; }
+
+	[JsonProperty("intonationScale", Required = Required.Always)]
+	public double IntonationScale { get; set; }
+
+	[JsonProperty("volumeScale", Required = Required.Always)]
+	public double VolumeScale { get; set; }
+
+	[JsonProperty("prePhonemeLength", Required = Required.Always)]
+	public double PrePhonemeLength { get; set; }
+
+
+	[JsonProperty("postPhonemeLength", Required = Required.Always)]
+	public double PostPhonemeLength { get; set; }
+
+
+	[JsonProperty("outputSamplingRate", Required = Required.Always)]
+	public int OutputSamplingRate { get; set; }
+
+	[JsonProperty("outputStereo", Required = Required.Always)]
+	public bool OutputStereo { get; set; }
+
+	[JsonProperty("kana")]
+	public string? Kana { get; set; }
+}
+
+[JsonObject]
+file class AccentPhrases : JsonObject {
+	[JsonProperty("moras", Required = Required.Always)]
+	public Mora[] Moras { get; set; }
+
+	[JsonProperty("accent", Required = Required.Always)]
+	public int Accent { get; set; }
+
+	[JsonProperty("pause_mora")]
+	public PauseMora? PauseMora { get; set; }
+
+	[JsonProperty("is_interrogative")]
+	public bool? IsInterrogative { get; set; }
+}
+
+[JsonObject]
+file class Mora : JsonObject {
+	[JsonProperty("text", Required = Required.Always)]
+	public string Text { get; set; }
+
+	[JsonProperty("consonant")]
+	public string? Consonant { get; set; }
+
+	[JsonProperty("consonant_length")]
+	public double? consonant_length { get; set; }
+
+	[JsonProperty("vowel", Required = Required.Always)]
+	public string Vowel { get; set; }
+
+	[JsonProperty("vowel_length", Required = Required.Always)]
+	public double VowelLength { get; set; }
+
+	[JsonProperty("pitch", Required = Required.Always)]
+	public double Pitch { get; set; }
+}
+
+[JsonObject]
+file class PauseMora : JsonObject {
+	[JsonProperty("text", Required = Required.Always)]
+	public string Text { get; set; }
+
+	[JsonProperty("consonant")]
+	public string? Consonant { get; set; }
+
+	[JsonProperty("consonant_length")]
+	public double? ConsonantLength { get; set; }
+
+	[JsonProperty("vowel", Required = Required.Always)]
+	public string Vowel { get; set; }
+
+	[JsonProperty("vowel_length", Required = Required.Always)]
+	public double VowelLength { get; set; }
+
+	[JsonProperty("pitch", Required = Required.Always)]
+	public double Pitch { get; set; }
+}
+
+[JsonObject]
+file class Speaker : JsonObject {
+	[JsonProperty("supported_features")]
+	public SpeakerSupportedFeature? SupportedFeatures { get; set; }
+
+	[JsonProperty("name", Required = Required.Always)]
+	public string Name { get; set; }
+
+	[JsonProperty("speaker_uuid", Required = Required.Always)]
+	public string SpeakerUuid { get; set; }
+
+	[JsonProperty("styles", Required = Required.Always)]
+	public SpeakerStyle[] Styles { get; set; }
+
+	[JsonProperty("version")]
+	public string? Version { get; set; }
+}
+
+[JsonObject]
+file class SpeakerSupportedFeature : JsonObject {
+	[JsonProperty("permitted_synthesis_morphing")]
+	public string? PermittedSynthesisMorphing { get; set; } // "ALL" "SELF_ONLY" "NOTHING"
+}
+
+
+[JsonObject]
+file class SpeakerStyle : JsonObject {
+	[JsonProperty("name", Required = Required.Always)]
+	public string Name { get; set; }
+
+	[JsonProperty("id", Required = Required.Always)]
+	public int Id { get; set; }
+}

--- a/src/cs-illuminate/VoiceLink/IVoiceClient.cs
+++ b/src/cs-illuminate/VoiceLink/IVoiceClient.cs
@@ -64,8 +64,31 @@ public record AudioCaptreStart(string TargetExe) : IStartObject;
 /// <param name="ToneScale">抑揚（0～100）</param>
 /// <param name="Alpha">声質（0～100）</param>
 /// <param name="Components">感情パラメータ(パラメータ名, 値)</param>
-public record CeVioSpeechClient(string Cast, uint Volume, uint Speed, uint Tone, uint ToneScale, uint Alpha, IEnumerable<(string Name, uint Value)> Components) : ISpeechObject;
+public record CeVioSpeechClient(
+	string Cast,
+	uint Speed,
+	uint Tone,
+	uint ToneScale,
+	uint Alpha,
+	IEnumerable<(string Name, uint Value)> Components) : ISpeechObject {
 
+	public uint Volume { get; init; } = 50;
+}
+
+
+public record VoiceVoxSpeechClient(
+	string Host,
+	int Port,
+	int Speaker,
+	double SpeedScale,
+	double PitchScale,
+	double IntonationScale,
+	System.IO.MemoryStream Writer) : ISpeechObject {
+
+	public double VolumeScale { get; init; } = 1.0;
+	public int OutputSamplingRate { get; init; } = 48000;
+	public bool OutputStereo { get; init; } = false;
+}
 
 /// <summary>オーディオキャプチャのためのクライアントパラメータ</summary>
 public interface IAudioCaptireClient : IClientObject {

--- a/src/cs-illuminate/VoiceLink/VoiceLink.csproj
+++ b/src/cs-illuminate/VoiceLink/VoiceLink.csproj
@@ -17,5 +17,6 @@
   </ItemGroup>
 	
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/cs-illuminate/illuminate/Models/CommandOptions.cs
+++ b/src/cs-illuminate/illuminate/Models/CommandOptions.cs
@@ -15,7 +15,8 @@ class CommandOptions {
 		aivoice,
 		aivoice2,
 		ceviocs,
-		cevioai
+		cevioai,
+		voicevox,
 	}
 
 	[Option("master", Required = false, HelpText = "-")]
@@ -31,6 +32,11 @@ class CommandOptions {
 
 	[Option("log_dir", Required = false, HelpText = "-")]
 	public string LogDir { get; set; } = "";
+
+	[Option("wasapi_id", Required = false, HelpText = "-")]
+	public string WasapiId { get; set; } = "";
+
+
 	/*
 	[Option("log_", Required = false, HelpText = "-")]
 	public bool Launch { get; set; }
@@ -59,6 +65,22 @@ class CommandOptions {
 	public uint CeVioAlpha { get; set; } = 100u;
 	[Option("cevio_components", Separator = ',', Required = false, HelpText = "-")]
 	public IEnumerable<string> CeVioComponents { get; set; } = Array.Empty<string>();
+
+
+	[Option("voicevox_host", Required = false, HelpText = "-")]
+	public string VoiceVoxHost { get; set; } = "127.0.0.1";
+	[Option("voicevox_port", Required = false, HelpText = "-")]
+	public int VoiceVoxPort { get; set; } = 50021;
+	[Option("voicevox_speaker", Required = false, HelpText = "-")]
+	public int VoiceVoxSpeaker { get; set; } = 0;
+	[Option("voicevox_speed", Required = false, HelpText = "-")]
+	public double VoiceVoxSpeedScale { get; set; } = 1.0;
+	[Option("voicevox_pitch", Required = false, HelpText = "-")]
+	public double VoiceVoxPitchScale { get; set; } = 1.0;
+	[Option("voicevox_intonation", Required = false, HelpText = "-")]
+	public double VoiceVoxIntonationScale { get; set; } = 1.0;
+
+
 
 	public (bool IsValid, string ErrorText) Validate() {
 		var retText = new StringBuilder();
@@ -93,15 +115,41 @@ class CommandOptions {
 				retText.AppendLine("CeVIO:cevio_tone_scaleの有効範囲は0～100です");
 			}
 			if (100u < this.CeVioAlpha) {
-				retText.AppendLine("CeVIO:cevio_componentsの書式が間違っています");
+				retText.AppendLine("CeVIO:cevio_alphaの有効範囲は0～100です");
 			}
 			try {
 				this.ParseCeVioComponents();
 			}
 			catch(FormatException) {
-				retText.AppendLine("CeVIO:cevio_alphaの有効範囲は0～100です");
+				retText.AppendLine("CeVIO:cevio_componentsの書式が間違っています");
 			}
 		}
+
+
+		if (this.Voice switch {
+			VoiceClientType.voicevox => true,
+			_ => false
+		}) {
+			if (0d <= this.VoiceVoxSpeedScale) {
+				retText.AppendLine("VoiceVox:voicevox_speedの有効範囲は0～2です");
+			}
+			if (0d <= this.VoiceVoxPitchScale) {
+				retText.AppendLine("VoiceVox:voicevox_pitchの有効範囲は0～2です");
+			}
+			if (0d <= this.VoiceVoxIntonationScale) {
+				retText.AppendLine("VoiceVox:voicevox_intonationの有効範囲は0～2です");
+			}
+			if (this.VoiceVoxSpeedScale <= 2d) {
+				retText.AppendLine("VoiceVox:voicevox_speedの有効範囲は0～2です");
+			}
+			if (this.VoiceVoxPitchScale <= 2d) {
+				retText.AppendLine("VoiceVox:voicevox_pitchの有効範囲は0～2です");
+			}
+			if (this.VoiceVoxIntonationScale <= 2d) {
+				retText.AppendLine("VoiceVox:voicevox_intonationの有効範囲は0～2です");
+			}
+		}
+
 		return (retText.Length == 0, retText.ToString());
 	}
 

--- a/src/cs-illuminate/illuminate/Models/RecognitionObject.cs
+++ b/src/cs-illuminate/illuminate/Models/RecognitionObject.cs
@@ -10,6 +10,9 @@ public record class RecognitionObject {
 #pragma warning disable CS8618
 	[JsonProperty("transcript", Required = Required.Always)]
 	public string Transcript { get; init; }
+
+	[JsonProperty("translate", Required = Required.Always)]
+	public string Translate { get; init; }
 #pragma warning restore
 
 	[JsonProperty("finish", Required = Required.Always)]

--- a/src/cs-illuminate/illuminate/illuminate.csproj
+++ b/src/cs-illuminate/illuminate/illuminate.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Fleck" Version="1.2.0" />
-    <PackageReference Include="NAudio.Wasapi" Version="2.2.1" />
+	  <PackageReference Include="NAudio.Wasapi" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="Lucene.Net.Analysis.Kuromoji" Version="4.8.0-beta00016" />

--- a/src/py-recognition/src/output.py
+++ b/src/py-recognition/src/output.py
@@ -37,7 +37,8 @@ class VrChatOutputer(RecognitionOutputer):
         self.__client = None
 
     def output(self, text_ja:str, text_en:str) -> str:
-        self.__client.send_message("/chatbox/input", [text_ja, True, True])
+        if self.__client != None:
+            self.__client.send_message("/chatbox/input", [text_ja, True, True])
         return text_ja
 
 class WebSocketOutputer(RecognitionOutputer):

--- a/src/py-recognition/src/output_subtitle.py
+++ b/src/py-recognition/src/output_subtitle.py
@@ -29,8 +29,9 @@ class SubtitleOutputer(RecognitionOutputer):
         t.setDaemon(True)
         t.start()
 
-    def output(self, text_ja:str, text_en:str) -> None:
+    def output(self, text_ja:str, text_en:str) -> str:
         self.__prv_time = time.time()
+        return text_ja
 
 
 class NopSubtitleOutputer(SubtitleOutputer):
@@ -58,7 +59,7 @@ class FileSubtitleOutputer(SubtitleOutputer):
             encoding="UTF-8",
             newline="")
 
-    def output(self, text_ja:str, text_en:str) -> None:
+    def output(self, text_ja:str, text_en:str) -> str:
         self.__io_ja.seek(0)
         self.__io_en.seek(0)
         self.__io_ja.truncate(0)
@@ -67,7 +68,7 @@ class FileSubtitleOutputer(SubtitleOutputer):
         self.__io_en.write(text_en)
         self.__io_ja.flush()
         self.__io_en.flush()
-        super().output(text_ja, text_en)
+        return super().output(text_ja, text_en)
 
 
 
@@ -96,7 +97,7 @@ class ObsV5SubtitleOutputer(SubtitleOutputer):
             self.__port,
             self.__password)
 
-    def output(self, text_ja:str, text_en:str) -> None:
+    def output(self, text_ja:str, text_en:str) -> str:
         if self.__obs is None:
             self.__try_connect(
                 self.__host,
@@ -122,7 +123,7 @@ class ObsV5SubtitleOutputer(SubtitleOutputer):
             except websocket._exceptions.WebSocketConnectionClosedException:
                 self.__obs = None
                 self._logger.error("OBSとの接続が閉じられました")
-        super().output(text_ja, text_en)
+        return super().output(text_ja, text_en)
 
     def __try_connect(self, host, port, password) -> bool:
         try:


### PR DESCRIPTION
ボイロの発声が長い場合発声が終わる前に次の字幕が出ていた問題を修正しました。なおゆかりねっと+ボイロなどilluminateを介さない場合の字幕の動きは今までと変わりません。