### PR TITLE
20251108更新版

### DIFF
--- a/src/cs-recognition-frontend/Helpers/Interop.cs
+++ b/src/cs-recognition-frontend/Helpers/Interop.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Haru.Kei.Helpers;
+static class Interop {
+	[DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+	public static extern nint LoadLibrary(string dllToLoad);
+
+	[DllImport("kernel32.dll", CharSet = CharSet.Ansi, EntryPoint = "GetProcAddress")]
+	public static extern nint GetProcAddress(nint hModule, string procedureName);
+
+	[DllImport("kernel32.dll")]
+	public static extern bool FreeLibrary(nint hModule);
+}

--- a/src/cs-recognition-frontend/Models/Config.Binder.cs
+++ b/src/cs-recognition-frontend/Models/Config.Binder.cs
@@ -13,13 +13,21 @@ using Reactive.Bindings;
 
 namespace Haru.Kei.Models;
 public class ConfigBinder : INotifyPropertyChanged {
+	delegate int cuInit(int flags);
+	delegate int cuDeviceGetCount(ref int count);
+
+	public class TranscribeItem(string name, bool enabled) {
+		public ReactivePropertySlim<string> Name { get; } = new(initialValue: name);
+		public ReactivePropertySlim<bool> Enabled { get; } = new(initialValue: enabled);
+	}
+
 	public event PropertyChangedEventHandler? PropertyChanged;
 
-	private readonly string[] TranscribeModels = {
-		"設定しない",
-		"AI音声認識",
-		"google音声認識",
-	};
+	private readonly (string Name, bool Enabled)[] TranscribeModels = [
+		("設定しない", true),
+		("AI音声認識", CanUsedCuda()),
+		("google音声認識", true),
+	];
 	public const int TranscribeIndexNull = 0;
 	public const int TranscribeIndexAi = 1;
 	public const int TranscribeIndexGoogle = 2;
@@ -71,7 +79,7 @@ public class ConfigBinder : INotifyPropertyChanged {
 	public const int VadMethodIndexYAMNet = 2;
 
 	// モデル
-	public ReactiveCollection<string> TranscribeModelsBinder { get; }
+	public ReactiveCollection<TranscribeItem> TranscribeModelsBinder { get; }
 	public ReactivePropertySlim<int> TranscribeModeIndex { get; }
 	public ReactivePropertySlim<string> GoogleLanguageBinding { get; }
 	public ReactivePropertySlim<string> GoogleTimeoutBinding { get; set; }
@@ -131,7 +139,7 @@ public class ConfigBinder : INotifyPropertyChanged {
 	public ConfigBinder(Config config) {
 		// モデル
 		this.TranscribeModelsBinder = new();
-		this.TranscribeModelsBinder.AddRangeOnScheduler(TranscribeModels);
+		this.TranscribeModelsBinder.AddRangeOnScheduler(TranscribeModels.Select(x => new TranscribeItem(x.Name, x.Enabled)));
 		this.TranscribeModeIndex = new(initialValue: config.TranscribeModel switch {
 			"kotoba_whisper" => TranscribeIndexAi,
 			"google_mix" => TranscribeIndexGoogle,
@@ -363,6 +371,35 @@ public class ConfigBinder : INotifyPropertyChanged {
 	}
 	public ReadOnlyReactivePropertySlim<string> IlluminateClientDialogFilter { get; }
 	public ReadOnlyReactivePropertySlim<string?> IlluminateClientDialogDirectory { get; }
+
+	private static bool CanUsedCuda() {
+		var cudaDevice = 0;
+		var hNvcuda = default(nint);
+		try {
+			hNvcuda = Helpers.Interop.LoadLibrary("nvcuda.dll");
+			if(hNvcuda == 0) {
+				return false;
+			}
+
+			var pCuInit = Helpers.Interop.GetProcAddress(hNvcuda, "cuInit");
+			var pCuDeviceGetCount = Helpers.Interop.GetProcAddress(hNvcuda, "cuDeviceGetCount");
+			if((pCuInit == 0) || (pCuDeviceGetCount == 0)) {
+				return false;
+			}
+
+			var cuInit = System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<cuInit>(pCuInit);
+			var cuDeviceGetCount = System.Runtime.InteropServices.Marshal.GetDelegateForFunctionPointer<cuDeviceGetCount>(pCuDeviceGetCount);
+
+			cuInit(0);
+			cuDeviceGetCount(ref cudaDevice);
+		}
+		finally {
+			if(0 != hNvcuda) {
+				Helpers.Interop.FreeLibrary(hNvcuda);
+			}
+		}
+		return 0 < cudaDevice;
+	}
 
 	private string ToString<T>(T v) {
 		if(v == null) {

--- a/src/cs-recognition-frontend/Models/Config.Binder.cs
+++ b/src/cs-recognition-frontend/Models/Config.Binder.cs
@@ -79,6 +79,7 @@ public class ConfigBinder : INotifyPropertyChanged {
 	public ReactiveCollection<string> TranslateModelsBinder { get; set; }
 	public ReactivePropertySlim<int> TranslateModelIndex { get; }
 	public ReadOnlyReactivePropertySlim<Visibility> GoogleItemVisibility { get; }
+	private ReadOnlyReactivePropertySlim<Visibility> _GoogleTimeoutError { get; }
 	public ReadOnlyReactivePropertySlim<Visibility> GoogleTimeoutError { get; }
 
 	// マイク
@@ -165,9 +166,13 @@ public class ConfigBinder : INotifyPropertyChanged {
 				TranscribeIndexGoogle => Visibility.Visible,
 				_ => Visibility.Hidden,
 			}).ToReadOnlyReactivePropertySlim();
-		this.GoogleTimeoutError = this.GoogleTimeoutBinding
+		this._GoogleTimeoutError = this.GoogleTimeoutBinding
 			.Select(x => this.ToFloatError(x))
 			.ToReadOnlyReactivePropertySlim();
+		this.GoogleTimeoutError = this._GoogleTimeoutError
+			.CombineLatest(this.GoogleItemVisibility,
+				(p1, p2) => this.Visibilities2Visibility(p1, p2)
+			).ToReadOnlyReactivePropertySlim();
 
 		// マイク
 		this.MicDevicesBinder = new();
@@ -410,5 +415,17 @@ public class ConfigBinder : INotifyPropertyChanged {
 		} else {
 			return Visibility.Visible;
 		}
+	}
+
+	private Visibility Visibilities2Visibility(params Visibility[] visibilities) {
+		var ret = true;
+		foreach(var v in visibilities) {
+			ret &= (v == Visibility.Visible);
+		}
+
+		return ret switch {
+			true => Visibility.Visible,
+			_ => Visibility.Collapsed,
+		};
 	}
 }

--- a/src/cs-recognition-frontend/Models/Config.Binder.cs
+++ b/src/cs-recognition-frontend/Models/Config.Binder.cs
@@ -90,8 +90,13 @@ public class ConfigBinder : INotifyPropertyChanged {
 	public ReactivePropertySlim<int> HpfParamaterIndex { get; }
 	public ReactiveCollection<string> VadMethodsBinder { get; }
 	public ReactivePropertySlim<int> VadMethodsIndex { get; }
+	public ReactivePropertySlim<string> VadSileroThresholdBinder { get; }
+	public ReadOnlyReactivePropertySlim<Visibility> VadSileroOptionVisibility { get; }
 	public ReadOnlyReactivePropertySlim<Visibility> MicrophoneThresholdDbError { get; }
 	public ReadOnlyReactivePropertySlim<Visibility> MicrophoneRecordMinDurationError { get; }
+	// VadSileroThresholdErrorでRx合成用の一時プロパティ
+	private ReadOnlyReactivePropertySlim<Visibility> _VadSileroThresholdError { get; }
+	public ReadOnlyReactivePropertySlim<Visibility> VadSileroThresholdError { get; }
 
 	// ゆかりねっと連携
 	public ReactivePropertySlim<bool> IsUsedYukarinetteBinding { get; }
@@ -218,13 +223,42 @@ public class ConfigBinder : INotifyPropertyChanged {
 			VadMethodIndexYAMNet => "yamnet",
 			_ => null
 		});
-
+		this.VadSileroThresholdBinder = new(initialValue: this.ToString(config.VadSileroThreshold));
+		this.VadSileroThresholdBinder.Subscribe(x => {
+			config.VadSileroThreshold = this.ToFloat(x);
+		});
+		this.VadSileroOptionVisibility = this.VadMethodsIndex
+			.Select(x => x switch {
+				1 => Visibility.Visible,
+				_ => Visibility.Hidden,
+			}).ToReadOnlyReactivePropertySlim();
 		this.MicrophoneThresholdDbError = this.MicrophoneThresholdDbBinder
 			.Select(x => this.ToFloatError(x))
 			.ToReadOnlyReactivePropertySlim();
 		this.MicrophoneRecordMinDurationError = this.MicrophoneRecordMinDurationBinder
 			.Select(x => this.ToFloatError(x))
 			.ToReadOnlyReactivePropertySlim();
+		this._VadSileroThresholdError = this.VadSileroThresholdBinder
+			.Select(x => x switch {
+				string v when !string.IsNullOrEmpty(v) => ToFloat(v) switch {
+					null => Visibility.Visible,
+					float vv when(0 <= vv) && (vv <= 1.0f) => Visibility.Collapsed,
+					_ => Visibility.Visible,
+				},
+				_ => Visibility.Collapsed
+			}).ToReadOnlyReactivePropertySlim();
+		this.VadSileroThresholdError = this._VadSileroThresholdError
+			.CombineLatest(this.VadSileroOptionVisibility,
+				(p1, p2) => {
+					static bool conv(Visibility v) => v switch {
+						Visibility.Visible => true,
+						_ => false
+					};
+					return (conv(p1) && conv(p2)) switch {
+						true => Visibility.Visible,
+						_ => Visibility.Collapsed
+					};
+				}).ToReadOnlyReactivePropertySlim();
 
 		// ゆかりねっと連携
 		this.IsUsedYukarinetteBinding = new(initialValue: config.IsUsedYukarinette);

--- a/src/cs-recognition-frontend/Models/Config.cs
+++ b/src/cs-recognition-frontend/Models/Config.cs
@@ -40,6 +40,8 @@ public class Config {
 	public int? HpfParamater { get; set; } = null;
 	[JsonProperty("vad")]
 	public string? Vad { get; set; } = null;
+	[JsonProperty("vad_silero_threshold")]
+	public float? VadSileroThreshold { get; set; } = null;
 
 	// ゆかりねっと連携
 	[JsonProperty("out:yukarinette")]
@@ -283,6 +285,7 @@ public class Config {
 		arg(opt, "--mic_db_threshold", this.MicrophoneThresholdDb);
 		arg(opt, "--mic_record_min_duration", this.MicrophoneRecordMinDuration);
 		arg(opt, "--vad", this.Vad);
+		arg(opt, "--vad_silero_threshold", this.VadSileroThreshold);
 		arg(opt, "--filter_hpf", this.HpfParamater);
 
 		opt.Append($"--out \"print\" "); // ないと本体が起動しないのでいったん付与する

--- a/src/cs-recognition-frontend/Views/MainWindow.xaml
+++ b/src/cs-recognition-frontend/Views/MainWindow.xaml
@@ -342,12 +342,6 @@
                             Grid.Column="0" Grid.Row="8"
                             FontSize="{DynamicResource YsrFontSize}">
                             <Run Text="音声検出方法" />
-                            <Run
-                                Foreground="{DynamicResource YspInfoBrush}"
-                                BaselineAlignment="Bottom"
-                                FontFamily="{StaticResource SymbolFont}"
-                                Text="{StaticResource FontSymbolInfo}"
-                                ToolTip="" />
                         </TextBlock>
                         <ComboBox
                             Grid.Column="3" Grid.Row="8"

--- a/src/cs-recognition-frontend/Views/MainWindow.xaml
+++ b/src/cs-recognition-frontend/Views/MainWindow.xaml
@@ -369,7 +369,7 @@
                                 BaselineAlignment="Bottom"
                                 FontFamily="{StaticResource SymbolFont}"
                                 Text="{StaticResource FontSymbolInfo}"
-                                ToolTip="0.0～1.0の間で指定してください。初期値は0.5です" />
+                                ToolTip="音声検出の閾値を設定します。0.0～1.0の間で指定してください。0に近づくほど厳しく判定します。初期値は0.5です" />
                         </TextBlock>
                         <TextBlock
                             Grid.Column="2" Grid.Row="10"

--- a/src/cs-recognition-frontend/Views/MainWindow.xaml
+++ b/src/cs-recognition-frontend/Views/MainWindow.xaml
@@ -107,9 +107,16 @@
                         </TextBlock>
                         <ComboBox
                             Grid.Column="3" Grid.Row="0"
+                            DisplayMemberPath="Name"
                             ItemsSource="{Binding ConfigBinder.TranscribeModelsBinder, Mode=OneWay}"
                             SelectedIndex="{Binding ConfigBinder.TranscribeModeIndex.Value, Mode=TwoWay}"
-                            />
+                            >
+                            <ComboBox.ItemContainerStyle>
+                                <Style TargetType="{x:Type ComboBoxItem}">
+                                    <Setter Property="IsEnabled" Value="{Binding Enabled.Value}"/>
+                                </Style>
+                            </ComboBox.ItemContainerStyle>
+                        </ComboBox>
 
                         <TextBlock
                             Grid.Column="0" Grid.Row="2"

--- a/src/cs-recognition-frontend/Views/MainWindow.xaml
+++ b/src/cs-recognition-frontend/Views/MainWindow.xaml
@@ -235,6 +235,8 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="24" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="12" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="24" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
@@ -356,7 +358,38 @@
                             SelectedIndex="{Binding ConfigBinder.VadMethodsIndex.Value, Mode=TwoWay}"
                             />
 
-                        <Grid Grid.Column="3" Grid.Row="10" HorizontalAlignment="Right">
+                        <TextBlock
+                            Grid.Column="0" Grid.Row="10"
+                            Visibility="{Binding ConfigBinder.VadSileroOptionVisibility.Value, Mode=OneWay}"
+                            FontSize="{DynamicResource YsrFontSize}"
+                            >
+                            <Run Text="Sielo VAD閾値" />
+                            <Run
+                                Foreground="{DynamicResource YspInfoBrush}"
+                                BaselineAlignment="Bottom"
+                                FontFamily="{StaticResource SymbolFont}"
+                                Text="{StaticResource FontSymbolInfo}"
+                                ToolTip="0.0～1.0の間で指定してください。初期値は0.5です" />
+                        </TextBlock>
+                        <TextBlock
+                            Grid.Column="2" Grid.Row="10"
+                            Margin="4,0,4,0"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource YspErrorBrush}"
+                            FontSize="{DynamicResource YsrFontSize}"
+                            FontFamily="{StaticResource SymbolFont}" 
+                            Text="{StaticResource FontSymbolStatusErrorFull}"
+                            Visibility="{Binding ConfigBinder.VadSileroThresholdError.Value, Mode=OneWay}"
+                            />
+                        <TextBox
+                            Grid.Column="3" Grid.Row="10" 
+                            Visibility="{Binding ConfigBinder.VadSileroOptionVisibility.Value, Mode=OneWay}"
+                            FontSize="{DynamicResource YsrFontSize}"
+                            Text="{Binding ConfigBinder.VadSileroThresholdBinder.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            />
+
+                        <Grid Grid.Column="3" Grid.Row="12" HorizontalAlignment="Right">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="92" />
                                 <ColumnDefinition Width="8" />

--- a/src/py-recognition/src/__main__.py
+++ b/src/py-recognition/src/__main__.py
@@ -289,7 +289,8 @@ def main(
         # VADフィルタの準備
         filter_vad_inst:filter.VoiceActivityDetectorFilter = {
             val.VAD_VALUE_SILERO: lambda: filter.SileroVadFilter(
-                val.MIC_SAMPLE_RATE),
+                val.MIC_SAMPLE_RATE,
+                vad_silero_threshold),
             val.VAD_VALUE_YAMNET: lambda: filter.YAMNetVadFilter(
                 val.MIC_SAMPLE_RATE),
         }[vad]()

--- a/src/py-recognition/src/filter.py
+++ b/src/py-recognition/src/filter.py
@@ -85,9 +85,12 @@ class SileroVadFilter(VoiceActivityDetectorFilter):
 
     def __init__(   
         self,
-        sampling_rate:int):
+        sampling_rate:int,
+        threshold):
 
         self.__model = load_silero_vad()
+        self.__sampling_rate = sampling_rate
+        self.__threshold = threshold
 
     @property
     def mic_pause_duration(self) -> float:
@@ -103,7 +106,9 @@ class SileroVadFilter(VoiceActivityDetectorFilter):
         auido, _ = torchaudio.load(bytes_io)
         speech_timestamps = get_speech_timestamps(
             auido,
-            self.__model)
+            self.__model,
+            threshold=self.__threshold,
+            sampling_rate=self.__sampling_rate)
         return 0 < len(speech_timestamps)
     
 


### PR DESCRIPTION
・[修正]GUIのバグ修正
　→一部表示がバグってたので修正。

・[追加]Sileo VADの閾値オプションを設定できるように機能追加
　→初期値は0.5。0に近いほど強力にノイズを無視し小声でも判定しやすくなる可能性があります。
　　初期値以外に設定する場合はご自身のマイク周りの環境に合わせて調整をお願いします。

・[追加]GUI側にCUDA使用可の判定処理追加
　→CUDAが利用できない場合AI音声認識できないようにしました。